### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/bin/SendSESMail.js
+++ b/bin/SendSESMail.js
@@ -11,7 +11,7 @@
 
 const parser = require('commander' ),
     path = require('path'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     crypto = require('crypto'),
     SESMailer = require('../index' ).commons.SESMailer,
     AWSCommonsFactory = require('../index').commons.AWSCommonsFactory;

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "commander": "^2.9.0",
     "lodash": "^4.5.0",
     "mime-types": "^2.1.10",
-    "node-uuid": "^1.4.7",
-    "simple-node-logger": "^0.93.12"
+    "simple-node-logger": "^0.93.12",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/fixtures/S3Dataset.js
+++ b/test/fixtures/S3Dataset.js
@@ -7,7 +7,7 @@
  */
 var randomData = require('random-fixture-data' ),
     crypto = require('crypto' ),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 var S3Dataset = function() {
     'use strict';

--- a/test/mocks/MockSES.js
+++ b/test/mocks/MockSES.js
@@ -4,7 +4,7 @@
  * @author: darryl.west@raincitysoftware.com
  * @created: 11/3/14 6:16 PM
  */
-var uuid = require('node-uuid' );
+var uuid = require('uuid' );
 
 var MockSES = function() {
     'use strict';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.